### PR TITLE
Use ace.c9 as script editor

### DIFF
--- a/source/user.scripts/pkg_build.sh
+++ b/source/user.scripts/pkg_build.sh
@@ -15,9 +15,9 @@ mkdir -p $tmpdir/usr/local/emhttp/plugins/user.scripts/javascript/ace/
 wget --no-check-certificate https://github.com/ajaxorg/ace-builds/archive/refs/tags/v${ACE_VERSION}.zip
 mkdir -p /tmp/ace
 unzip v${ACE_VERSION}.zip "ace-builds-${ACE_VERSION}/src-min-noconflict/*" -d "/tmp/ace"
-cp /tmp/ace/ace-builds-${ACE_VERSION}/src-min-noconflict/*.js $tmpdir/usr/local/emhttp/plugins/compose.manager/javascript/ace/
+cp /tmp/ace/ace-builds-${ACE_VERSION}/src-min-noconflict/*.js $tmpdir/usr/local/emhttp/plugins/user.scripts/javascript/ace/
 
-chmod -R +x $tmpdir/usr/local/emhttp/plugins/compose.manager/javascript/ace/
+chmod -R +x $tmpdir/usr/local/emhttp/plugins/user.scripts/javascript/ace/
 rm -R /tmp/ace
 rm v${ACE_VERSION}.zip
 

--- a/source/user.scripts/pkg_build.sh
+++ b/source/user.scripts/pkg_build.sh
@@ -4,10 +4,23 @@ tmpdir=/tmp/tmp.$(( $RANDOM * 19318203981230 + 40 ))
 plugin=$(basename ${DIR})
 archive="$(dirname $(dirname ${DIR}))/archive"
 version=$(date +"%Y.%m.%d")$1
+ACE_VERSION=1.4.14
 
 mkdir -p $tmpdir
 
 cp --parents -f $(find . -type f ! \( -iname "pkg_build.sh" -o -iname "sftp-config.json"  \) ) $tmpdir/
+
+#Install Ace Editor
+mkdir -p $tmpdir/usr/local/emhttp/plugins/user.scripts/javascript/ace/
+wget --no-check-certificate https://github.com/ajaxorg/ace-builds/archive/refs/tags/v${ACE_VERSION}.zip
+mkdir -p /tmp/ace
+unzip v${ACE_VERSION}.zip "ace-builds-${ACE_VERSION}/src-min-noconflict/*" -d "/tmp/ace"
+cp /tmp/ace/ace-builds-${ACE_VERSION}/src-min-noconflict/*.js $tmpdir/usr/local/emhttp/plugins/compose.manager/javascript/ace/
+
+chmod -R +x $tmpdir/usr/local/emhttp/plugins/compose.manager/javascript/ace/
+rm -R /tmp/ace
+rm v${ACE_VERSION}.zip
+
 cd $tmpdir
 makepkg -l y -c y ${archive}/${plugin}-${version}-x86_64-1.txz
 rm -rf $tmpdir

--- a/source/user.scripts/usr/local/emhttp/plugins/user.scripts/Userscripts.page
+++ b/source/user.scripts/usr/local/emhttp/plugins/user.scripts/Userscripts.page
@@ -90,7 +90,7 @@ foreach ($schedule as $scriptSchedule) {
 }
 $scheduleScript .= "</script>";
 ?>
-<script src="/plugins/compose.manager/javascript/ace/ace.js" type= "text/javascript"></script>
+<script src="/plugins/user.scripts/javascript/ace/ace.js" type= "text/javascript"></script>
 <script>
 var caURL = "/plugins/user.scripts/exec.php";
 var aceTheme=<?php echo (in_array($theme,['black','gray']) ? json_encode('ace/theme/tomorrow_night') : json_encode('ace/theme/tomorrow')); ?>;
@@ -387,6 +387,7 @@ function cancelEdit() {
 
 function saveEdit() {
   var script = $("#editScriptName").html();
+  var editor = ace.edit("itemEditor");
   var scriptContents = editor.getValue();
   
   $.post(caURL,{action:'saveScript',script:script,scriptContents:scriptContents},function(data) {

--- a/source/user.scripts/usr/local/emhttp/plugins/user.scripts/Userscripts.page
+++ b/source/user.scripts/usr/local/emhttp/plugins/user.scripts/Userscripts.page
@@ -90,8 +90,16 @@ foreach ($schedule as $scriptSchedule) {
 }
 $scheduleScript .= "</script>";
 ?>
+<script src="/plugins/compose.manager/javascript/ace/ace.js" type= "text/javascript"></script>
 <script>
 var caURL = "/plugins/user.scripts/exec.php";
+var aceTheme=<?php echo (in_array($theme,['black','gray']) ? json_encode('ace/theme/tomorrow_night') : json_encode('ace/theme/tomorrow')); ?>;
+
+$(function() {
+  var editor = ace.edit("itemEditor");
+  editor.setTheme(aceTheme);
+  editor.setShowPrintMargin(false);
+})
 
 function abortScript(name) {
    swal({
@@ -342,6 +350,21 @@ function editDesc(myID) {
   $("#"+origID).tooltipster("enable");
 }
 
+function getModeForShebang(data)
+{
+  var firstLine = data.split('\n')[0];
+  if (firstLine.startsWith("#!")) {
+    if (firstLine.includes("bash") || firstLine.includes("sh")) {
+      return "ace/mode/sh";
+    } else if (firstLine.includes("php") ) {
+      return "ace/mode/php";
+    } else if (firstLine.includes("perl") ) {
+      return "ace/mode/perl";
+    }
+  }
+  return "ace/mode/text";
+}
+
 function editScript(myID) {
   var origID = myID;
   $("#"+myID).tooltipster("close");
@@ -349,8 +372,9 @@ function editScript(myID) {
   $.post(caURL,{action:'getScript',script:script},function(data) {
     if (data) {
       $("#editScriptName").html(script);
-      $("#editScript").html(data);
-      $("#editScript").val(data);
+      var editor = ace.edit("itemEditor");
+      editor.getSession().setValue(data);
+      editor.getSession().setMode(getModeForShebang(data));
       $(".editing").show();
 			window.scrollTo(0, 0);
     }
@@ -363,7 +387,7 @@ function cancelEdit() {
 
 function saveEdit() {
   var script = $("#editScriptName").html();
-  var scriptContents = $("#editScript").val();
+  var scriptContents = editor.getValue();
   
   $.post(caURL,{action:'saveScript',script:script,scriptContents:scriptContents},function(data) {
     if (data) {
@@ -499,7 +523,7 @@ function parseINIString(data){
 <div class='editing' hidden>
 <center><b>Editing /boot/config/plugins/user.scripts/scripts/<span id='editScriptName'></span>/script</b><br>
 <input type='button' value='Cancel' onclick='cancelEdit();'><input type='button' onclick='saveEdit();' value='Save Changes'><br>
-<textarea class='editing' id='editScript' style='width:90%; height:500px; border-color:red; font-family:monospace;'></textarea>
+<div id='itemEditor' style='width:90%; height:500px; position: relative;'></div>
 </center>
 </div>
 


### PR DESCRIPTION
These changes replace the script editor element with the ace.c9 editor from https://ace.c9.io/.
This editor is currently used by the compose.manager plugin and the new Dynamix File Manager plugin.
The min-noconflict version of ace is added to the plugin at build time.