### PR TITLE
add support for sorting output by script name or path

### DIFF
--- a/source/user.scripts/usr/local/emhttp/plugins/user.scripts/Userscripts.page
+++ b/source/user.scripts/usr/local/emhttp/plugins/user.scripts/Userscripts.page
@@ -525,10 +525,11 @@ function parseINIString(data){
 
 function sortScripts() {
     var sortBy = $('#sort').val();
+    var sortOrder = $('#sort-order').val();
     var toSort = $('tr').toArray();
     var sorted = toSort.sort(function(a,b){
-        if( a.dataset[sortBy].toLowerCase() > b.dataset[sortBy].toLowerCase()) return 1;
-        else if(a.dataset[sortBy].toLowerCase() < b.dataset[sortBy].toLowerCase()) return -1;
+        if( a.dataset[sortBy].toLowerCase() > b.dataset[sortBy].toLowerCase()) return sortOrder === 'desc' ? 1 : -1;
+        else if(a.dataset[sortBy].toLowerCase() < b.dataset[sortBy].toLowerCase()) return sortOrder === 'desc' ? -1 : 1;
         else return 0;
     });
 
@@ -542,6 +543,11 @@ function sortScripts() {
     <select id='sort' onchange='sortScripts()' name='sort' style='margin-left: 20px;'>
         <option value='namename'>Script Name</option>
         <option selected value='scriptname'>Script Path</option>
+    </select>
+    <label for='sort-order'>Order: </label>
+    <select id='sort-order' onchange='sortScripts()' name='sort-order' style='margin-left: 20px;'>
+        <option value='asc'>Ascending</option>
+        <option selected value='desc'>Descending</option>
     </select>
 </div>
 

--- a/source/user.scripts/usr/local/emhttp/plugins/user.scripts/Userscripts.page
+++ b/source/user.scripts/usr/local/emhttp/plugins/user.scripts/Userscripts.page
@@ -528,8 +528,8 @@ function sortScripts() {
     var sortOrder = $('#sort-order').val();
     var toSort = $('tr').toArray();
     var sorted = toSort.sort(function(a,b){
-        if( a.dataset[sortBy].toLowerCase() > b.dataset[sortBy].toLowerCase()) return sortOrder === 'desc' ? 1 : -1;
-        else if(a.dataset[sortBy].toLowerCase() < b.dataset[sortBy].toLowerCase()) return sortOrder === 'desc' ? -1 : 1;
+        if( a.dataset[sortBy].toLowerCase() > b.dataset[sortBy].toLowerCase()) return sortOrder === 'desc' ? -1 : 1;
+        else if(a.dataset[sortBy].toLowerCase() < b.dataset[sortBy].toLowerCase()) return sortOrder === 'desc' ? 1 : -1;
         else return 0;
     });
 
@@ -546,8 +546,8 @@ function sortScripts() {
     </select>
     <label for='sort-order'>Order: </label>
     <select id='sort-order' onchange='sortScripts()' name='sort-order' style='margin-left: 20px;'>
-        <option value='asc'>Ascending</option>
-        <option selected value='desc'>Descending</option>
+        <option selected value='asc'>Ascending</option>
+        <option value='desc'>Descending</option>
     </select>
 </div>
 

--- a/source/user.scripts/usr/local/emhttp/plugins/user.scripts/Userscripts.page
+++ b/source/user.scripts/usr/local/emhttp/plugins/user.scripts/Userscripts.page
@@ -340,15 +340,18 @@ $(function() {
 			var myID = origin.attr('id');
 			instance.content("Custom schedule format (standard cron entry):<br><tt>┌───────────── minute (0 - 59)<br></tt><tt>│ ┌───────────── hour (0 - 23)<br></tt><tt>│ │ ┌───────────── day of month (1 - 31)<br></tt><tt>│ │ │ ┌───────────── month (1 - 12)<br></tt><tt>│ │ │ │ ┌───────────── day of week (0 - 6) (Sunday to Saturday)<br></tt><tt>│ │ │ │ │<br></tt><tt>│ │ │ │ │<br></tt><tt>│ │ │ │ │<br></tt><tt>* * * * *</tt><br>See <a href='https://en.wikipedia.org/wiki/Cron' target='_blank'>HERE</a> for examples.  Or <a href='https://crontab.guru/' target='_blank'>HERE</a> for an online generator");
 		}
-	});  
-    attachEditScriptToolTipster();
-    var sort = localStorage.getItem('sort-by');
-    var order = localStorage.getItem('sort-order');
-    $('#sort').val(sort).change();
-    $('#sort-order').val(order).change();
-    $('.loader').hide();
-    $('table').show();
+	});
 
+	attachEditScriptToolTipster();
+	var sort = localStorage.getItem('sort-by');
+	var order = localStorage.getItem('sort-order');
+
+    if(sort) $('#sort').val(sort).change();
+    if(order) $('#sort-order').val(order).change();
+
+	$('.loader').hide();
+	$('table').show();
+  
   setInterval(function() {
     checkBackground();
   }, 1000);
@@ -567,6 +570,7 @@ function sortScripts() {
     $('tbody').html(sorted);
     attachEditScriptToolTipster();
 }
+
 </script>
 <a class='ca_cron' href='https://crontab.guru/' target='_blank'>What Is Cron</a><a class='ca_credits' style='float:right;cursor:pointer'>Credits</a>
 <div>

--- a/source/user.scripts/usr/local/emhttp/plugins/user.scripts/Userscripts.page
+++ b/source/user.scripts/usr/local/emhttp/plugins/user.scripts/Userscripts.page
@@ -320,8 +320,12 @@ $(function() {
 		}
 	});  
     attachEditScriptToolTipster();
+    var sort = localStorage.getItem('sort-by');
+    var order = localStorage.getItem('sort-order');
+    $('#sort').val(sort).change();
+    $('#sort-order').val(order).change();
+    $('table').show();
 
-  
   setInterval(function() {
     checkBackground();
   }, 1000);
@@ -526,6 +530,10 @@ function parseINIString(data){
 function sortScripts() {
     var sortBy = $('#sort').val();
     var sortOrder = $('#sort-order').val();
+
+    localStorage.setItem('sort-by', sortBy);
+    localStorage.setItem('sort-order', sortOrder);
+
     var toSort = $('tr').toArray();
     var sorted = toSort.sort(function(a,b){
         if( a.dataset[sortBy].toLowerCase() > b.dataset[sortBy].toLowerCase()) return sortOrder === 'desc' ? -1 : 1;
@@ -559,7 +567,7 @@ function sortScripts() {
 </div>
 
 <span class='tipsterallowed' hidden></span><br>
-<table>
+<table hidden>
 <?=$o?>
 </table>
 <br>

--- a/source/user.scripts/usr/local/emhttp/plugins/user.scripts/Userscripts.page
+++ b/source/user.scripts/usr/local/emhttp/plugins/user.scripts/Userscripts.page
@@ -90,6 +90,28 @@ foreach ($schedule as $scriptSchedule) {
 }
 $scheduleScript .= "</script>";
 ?>
+<style>
+    @keyframes loading {
+        from {
+            transform: rotateZ(0deg);
+        }
+
+        to {
+            transform: rotateZ(359deg);
+        }
+    }
+
+    .loader {
+        width: 100%;
+        display: flex;
+        padding: 50px 0;
+        justify-content: center;
+    }
+
+    #load {
+        animation: loading 2s linear infinite;
+    }
+</style>
 <script src="/plugins/user.scripts/javascript/ace/ace.js" type= "text/javascript"></script>
 <script>
 var caURL = "/plugins/user.scripts/exec.php";
@@ -324,6 +346,7 @@ $(function() {
     var order = localStorage.getItem('sort-order');
     $('#sort').val(sort).change();
     $('#sort-order').val(order).change();
+    $('.loader').hide();
     $('table').show();
 
   setInterval(function() {
@@ -567,6 +590,9 @@ function sortScripts() {
 </div>
 
 <span class='tipsterallowed' hidden></span><br>
+<div class='loader'>
+<i class='fa fa-spinner fa-5x' id='load'></i>
+</div>
 <table hidden>
 <?=$o?>
 </table>

--- a/source/user.scripts/usr/local/emhttp/plugins/user.scripts/Userscripts.page
+++ b/source/user.scripts/usr/local/emhttp/plugins/user.scripts/Userscripts.page
@@ -35,7 +35,7 @@ foreach ($userScripts as $script) {
   }
   $id = str_replace(".","-",$script);
   $id = str_replace(" ","",$id);
-  $o .= "<tr><td width='30%' style='text-align:initial'>";
+  $o .= "<tr data-nameName='$scriptName' data-scriptName=".escapeshellarg($script)."><td width='30%' style='text-align:initial'>";
   $o .= "<font size='2'><span class='ca_nameEdit' id='name$id' data-nameName='$scriptName' data-scriptName=".escapeshellarg($script)." style='font-size:1.9rem;cursor:pointer;color:#ff8c2f;'><i class='fa fa-gear'></i></span>&nbsp;&nbsp;<b><span style='color:#ff8c2f;'>$scriptName</span>&nbsp;</b></font><br>";
   if ( is_file("/boot/config/plugins/user.scripts/scripts/$script/description") ) {
     $description = @file_get_contents("/boot/config/plugins/user.scripts/scripts/$script/description");
@@ -260,6 +260,26 @@ function applySchedule() {
   $("#applyButton").prop("disabled",true);
 }
 
+function attachEditScriptToolTipster(){
+    $('.ca_nameEdit').tooltipster({
+		trigger: 'custom',
+		triggerOpen: {click:true,touchstart:true,mouseenter:true},
+		triggerClose:{click:true,scroll:false,mouseleave:true},
+		delay: 1000,
+		contentAsHTML: true,
+		animation: 'grow',
+		interactive: true,
+		viewportAware: true,
+		functionBefore: function(instance,helper) {
+			var origin = $(helper.origin);
+			var myID = origin.attr('id');
+			var name = $("#"+myID).html();
+			var scriptName = $("#"+myID).attr("data-scriptname");
+			instance.content("/boot/config/plugins/user.scripts/scripts/"+scriptName + "<br><center><input type='button' value='Edit Name' onclick='editName(&quot;"+myID+"&quot;);'><input type='button' value='Edit Description' onclick='editDesc(&quot;"+myID+"&quot;);'><input type='button' onclick='editScript(&quot;"+myID+"&quot;);' value='Edit Script'><input type='button' onclick='deleteScript(&quot;"+myID+"&quot;);' value='Delete Script'></center>");
+		}
+	});
+}
+
 $(function() {
 	if ( typeof caPluginUpdateCheck === "function" ) {
 		caPluginUpdateCheck("user.scripts.plg",{name:"User Scripts"});
@@ -299,23 +319,7 @@ $(function() {
 			instance.content("Custom schedule format (standard cron entry):<br><tt>┌───────────── minute (0 - 59)<br></tt><tt>│ ┌───────────── hour (0 - 23)<br></tt><tt>│ │ ┌───────────── day of month (1 - 31)<br></tt><tt>│ │ │ ┌───────────── month (1 - 12)<br></tt><tt>│ │ │ │ ┌───────────── day of week (0 - 6) (Sunday to Saturday)<br></tt><tt>│ │ │ │ │<br></tt><tt>│ │ │ │ │<br></tt><tt>│ │ │ │ │<br></tt><tt>* * * * *</tt><br>See <a href='https://en.wikipedia.org/wiki/Cron' target='_blank'>HERE</a> for examples.  Or <a href='https://crontab.guru/' target='_blank'>HERE</a> for an online generator");
 		}
 	});  
-	$('.ca_nameEdit').tooltipster({
-		trigger: 'custom',
-		triggerOpen: {click:true,touchstart:true,mouseenter:true},
-		triggerClose:{click:true,scroll:false,mouseleave:true},
-		delay: 1000,
-		contentAsHTML: true,
-		animation: 'grow',
-		interactive: true,
-		viewportAware: true,
-		functionBefore: function(instance,helper) {
-			var origin = $(helper.origin);
-			var myID = origin.attr('id');
-			var name = $("#"+myID).html();
-			var scriptName = $("#"+myID).attr("data-scriptname");
-			instance.content("/boot/config/plugins/user.scripts/scripts/"+scriptName + "<br><center><input type='button' value='Edit Name' onclick='editName(&quot;"+myID+"&quot;);'><input type='button' value='Edit Description' onclick='editDesc(&quot;"+myID+"&quot;);'><input type='button' onclick='editScript(&quot;"+myID+"&quot;);' value='Edit Script'><input type='button' onclick='deleteScript(&quot;"+myID+"&quot;);' value='Delete Script'></center>");
-		}
-	});
+    attachEditScriptToolTipster();
 
   
   setInterval(function() {
@@ -518,8 +522,28 @@ function parseINIString(data){
     });
     return value;
 }
+
+function sortScripts() {
+    var sortBy = $('#sort').val();
+    var toSort = $('tr').toArray();
+    var sorted = toSort.sort(function(a,b){
+        if( a.dataset[sortBy].toLowerCase() > b.dataset[sortBy].toLowerCase()) return 1;
+        else if(a.dataset[sortBy].toLowerCase() < b.dataset[sortBy].toLowerCase()) return -1;
+        else return 0;
+    });
+
+    $('tbody').html(sorted);
+    attachEditScriptToolTipster();
+}
 </script>
 <a class='ca_cron' href='https://crontab.guru/' target='_blank'>What Is Cron</a><a class='ca_credits' style='float:right;cursor:pointer'>Credits</a>
+<div>
+    <label for='sort'>Sort By: </label>
+    <select id='sort' onchange='sortScripts()' name='sort' style='margin-left: 20px;'>
+        <option value='namename'>Script Name</option>
+        <option selected value='scriptname'>Script Path</option>
+    </select>
+</div>
 
 <div class='editing' hidden>
 <center><b>Editing /boot/config/plugins/user.scripts/scripts/<span id='editScriptName'></span>/script</b><br>


### PR DESCRIPTION
This will allow you to sort by script name as well as the default sort of the script's path.  The body of the function `attachEditScriptToolTipster` on line 263 was moved from the function that runs on page load to attach the tooltip functionality for editing the script's name, description or script.  This was needed so it can be reattached after sorting since the elements are replaced in the DOM on sort.