### PR TITLE
Improve default scripts

### DIFF
--- a/source/user.scripts/usr/local/emhttp/plugins/user.scripts/Userscripts.page
+++ b/source/user.scripts/usr/local/emhttp/plugins/user.scripts/Userscripts.page
@@ -87,7 +87,7 @@ foreach ($schedule as $scriptSchedule) {
   $scheduleScript .= "$('#custom".$scriptSchedule['id']."').val('".$scriptSchedule['custom']."');";
   if ( $scriptSchedule['frequency'] == "custom" ) {
     $scheduleScript .= "$('#custom".$scriptSchedule['id']."').show();";
-  }      
+  }
 }
 $scheduleScript .= "</script>";
 ?>
@@ -178,7 +178,7 @@ function runScript(path) {
         });
       } else {
         actuallyRunScript(path,"");
-      }        
+      }
     }
   });
 }
@@ -244,13 +244,13 @@ function changeApply(scheduleID) {
 
 function applySchedule() {
   var schedule = new Array();
-  
+
   $(".schedule").each(function() {
     var script = $(this).data("script");
     var frequency = $(this).val();
     var custom = $("#custom"+this.id).val();
     var newSchedule = new Array(script,frequency,this.id,custom);
-    
+
     schedule.push(newSchedule);
   });
   $.post(caURL,{action:'applySchedule',schedule:schedule}, function(data) {
@@ -283,7 +283,7 @@ $(function() {
 			var myID = origin.attr('id');
 			instance.content("<div style='overflow:scroll; max-height:350px; height:550px; overflow-x:hidden; overflow-y:auto;'><center><img src='/plugins/user.scripts/images/user.scripts.png' width=96px><br><font size='6' color='white'>CA User Scripts</font><br><br><?=$caCredits?></div>");
 		}
-	});  
+	});
 	$('.ca_cron').tooltipster({
 		trigger: 'custom',
 		triggerOpen: {mouseenter:true},
@@ -299,7 +299,7 @@ $(function() {
 			var myID = origin.attr('id');
 			instance.content("Custom schedule format (standard cron entry):<br><tt>┌───────────── minute (0 - 59)<br></tt><tt>│ ┌───────────── hour (0 - 23)<br></tt><tt>│ │ ┌───────────── day of month (1 - 31)<br></tt><tt>│ │ │ ┌───────────── month (1 - 12)<br></tt><tt>│ │ │ │ ┌───────────── day of week (0 - 6) (Sunday to Saturday)<br></tt><tt>│ │ │ │ │<br></tt><tt>│ │ │ │ │<br></tt><tt>│ │ │ │ │<br></tt><tt>* * * * *</tt><br>See <a href='https://en.wikipedia.org/wiki/Cron' target='_blank'>HERE</a> for examples.  Or <a href='https://crontab.guru/' target='_blank'>HERE</a> for an online generator");
 		}
-	});  
+	});
 	$('.ca_nameEdit').tooltipster({
 		trigger: 'custom',
 		triggerOpen: {click:true,touchstart:true,mouseenter:true},
@@ -318,7 +318,7 @@ $(function() {
 		}
 	});
 
-  
+
   setInterval(function() {
     checkBackground();
   }, 1000);
@@ -378,7 +378,7 @@ function editScript(myID) {
     }
   });
 }
-  
+
 function cancelEdit() {
   $(".editing").hide();
 }
@@ -387,13 +387,13 @@ function saveEdit() {
   var script = $("#editScriptName").html();
   var editor = ace.edit("itemEditor");
   var scriptContents = editor.getValue();
-  
+
   $.post(caURL,{action:'saveScript',script:script,scriptContents:scriptContents},function(data) {
     if (data) {
       $(".editing").hide();
     }
   });
-  
+
 }
 
 function applyName(myID) {
@@ -544,7 +544,7 @@ function parseINIString(data){
 <span id='howToAdd' style='display:none'>
 To add your own user scripts, on the flash drive within the <font color='red'><b>config/plugins/user.scripts/scripts</b></font> folder, create a new folder for a script (the name does not matter of the folder <font color='red'> but it can only contain the following characters: letters ([A-Za-z]), digits ([0-9]), hyphens ("-"), underscores ("_"), colons (":"), periods ("."), and spaces (" ").</font>  Any other characters will impact the ability to run the script in the background.Within that folder, create a file called <font color='red'><b>description</b></font> which contains the description of the script.<br>
 Create a file called <font color='red'><b>script</b></font> which contains the actual script.
-Notepad can be used to do this on Windows machines, as prior to being executed, DOS line endings are automatically converted to Linux style line endings.  #!/bin/bash will even be automatically added to the start of the script before execution
+Notepad can be used to do this on Windows machines, as prior to being executed, DOS line endings are automatically converted to Linux style line endings.  <strong>#!/usr/bin/env bash</strong> will even be automatically added to the start of the script before execution
 Note that user interaction (ie: answering questions within the script) will NOT work.  Also, if there are any dependencies for the script (ie: other scripts), those can be called as usual, but make note that during execution, the script does not run from the flash drive (ie: include the full path to any dependency scripts)
 There is no point in running a particular script in the background if the script displays text that you need to see (ie: displaying the size of the docker logs)
 <br><br>
@@ -557,7 +557,7 @@ Additionally, scripts can contain inline variables which will modify the operati
 <b>name</b> this is the name of the script.  Without this variable, the GUI will display the folder's name<br>
 <b>argumentDescription</b> if present this will bring up a pop up asking the user for the argument list for the script.  Note that currently arguments do not accept spaces contained within one argument (ie: quoting and escaping spaces does NOT work)<br>
 <b>argumentDefault</b> this is the default arguments for the above<br>
-<br><b>How to implment these variables:</b> Immediately after the interpreter line (eg: immediately after the #!/bin/bash line), add these lines if you choose (you do not need to add all of them if you don't require them)<br>
+<br><b>How to implment these variables:</b> Immediately after the interpreter line (eg: immediately after the <strong>#!/usr/bin/env bash</strong> line), add these lines if you choose (you do not need to add all of them if you don't require them)<br>
 <br><font face='monospace'>
 &#35;description=this is the description of the script<br>
 &#35;foregroundOnly=true<br>

--- a/source/user.scripts/usr/local/emhttp/plugins/user.scripts/cron/user.script.start.daily.sh
+++ b/source/user.scripts/usr/local/emhttp/plugins/user.scripts/cron/user.script.start.daily.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
-/usr/local/emhttp/plugins/user.scripts/startSchedule.php daily
+#!/usr/bin/env bash
 
+/usr/local/emhttp/plugins/user.scripts/startSchedule.php daily

--- a/source/user.scripts/usr/local/emhttp/plugins/user.scripts/cron/user.script.start.hourly.sh
+++ b/source/user.scripts/usr/local/emhttp/plugins/user.scripts/cron/user.script.start.hourly.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
-/usr/local/emhttp/plugins/user.scripts/startSchedule.php hourly
+#!/usr/bin/env bash
 
+/usr/local/emhttp/plugins/user.scripts/startSchedule.php hourly

--- a/source/user.scripts/usr/local/emhttp/plugins/user.scripts/cron/user.script.start.monthly.sh
+++ b/source/user.scripts/usr/local/emhttp/plugins/user.scripts/cron/user.script.start.monthly.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
-/usr/local/emhttp/plugins/user.scripts/startSchedule.php monthly
+#!/usr/bin/env bash
 
+/usr/local/emhttp/plugins/user.scripts/startSchedule.php monthly

--- a/source/user.scripts/usr/local/emhttp/plugins/user.scripts/cron/user.script.start.weekly.sh
+++ b/source/user.scripts/usr/local/emhttp/plugins/user.scripts/cron/user.script.start.weekly.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
-/usr/local/emhttp/plugins/user.scripts/startSchedule.php weekly
+#!/usr/bin/env bash
 
+/usr/local/emhttp/plugins/user.scripts/startSchedule.php weekly

--- a/source/user.scripts/usr/local/emhttp/plugins/user.scripts/event/disks_mounted
+++ b/source/user.scripts/usr/local/emhttp/plugins/user.scripts/event/disks_mounted
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 /usr/local/emhttp/plugins/user.scripts/startSchedule.php start
 
 if [ ! -e /tmp/user.scripts/booted ]

--- a/source/user.scripts/usr/local/emhttp/plugins/user.scripts/event/stopping_svcs
+++ b/source/user.scripts/usr/local/emhttp/plugins/user.scripts/event/stopping_svcs
@@ -1,3 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 /usr/local/emhttp/plugins/user.scripts/startSchedule.php stop
 

--- a/source/user.scripts/usr/local/emhttp/plugins/user.scripts/exec.php
+++ b/source/user.scripts/usr/local/emhttp/plugins/user.scripts/exec.php
@@ -16,12 +16,12 @@ switch ($_POST['action']) {
 			echo "/usr/local/emhttp/plugins/user.scripts/arrayNotStarted.sh";
 			logger("Array must be started to run this script ($path)");
 			break;
-		}    
+		}
 		$newPath = str_replace("/boot/config/plugins/user.scripts/scripts/","/tmp/user.scripts/tmpScripts/",$path);
 		exec("mkdir -p ".escapeshellarg(dirname($newPath)));
 		$script = file_get_contents($path);
 		if ( ! startsWith($script,"#!") ) {
-			$script = "#!/bin/bash\n".$script;
+			$script = "#!/usr/bin/env bash\n".$script;
 		}
 		$script = str_replace("\r","",$script);
 		file_put_contents($newPath,$script);
@@ -38,7 +38,7 @@ switch ($_POST['action']) {
 			echo "/usr/local/emhttp/plugins/user.scripts/arrayNotStarted.sh";
 			logger("Array must be started to run this script ($path)");
 			break;
-		}    
+		}
 		$newPath = str_replace("/boot/config/plugins/user.scripts/scripts/","/usr/local/emhttp/plugins/tmp.user.scripts/tmpScripts/",$path);
 		exec("mkdir -p ".escapeshellarg(dirname($newPath)));
 		$script = file_get_contents($path);
@@ -59,9 +59,9 @@ switch ($_POST['action']) {
 		}
 		if ( ! is_array($scriptArray) ) {
 			$scriptArray = array();
-		}  
+		}
 		$untouchedScriptArray = $scriptArray;
-	 
+
 		$o = "<script>";
 		$running = @array_diff(scandir("/tmp/user.scripts/running"),array(".",".."));
 		if ( ! is_array($running) ) {
@@ -97,7 +97,7 @@ switch ($_POST['action']) {
 				$o .= "$('#trash$element').hide();";
 			}
 		}
-	 
+
 		foreach ( $untouchedScriptArray as $script) {
 			$element = getElement($script);
 
@@ -114,7 +114,7 @@ switch ($_POST['action']) {
 		break;
 	case 'abortScript':
 		$script = isset($_POST['name']) ? urldecode(($_POST['name'])) : "";
-		
+
 		$pid = file_get_contents("/tmp/user.scripts/running/$script");
 		exec("pkill -TERM -P $pid");
 		exec("kill -9 $pid");
@@ -136,10 +136,10 @@ switch ($_POST['action']) {
 		$name = isset($_POST['name']) ? urldecode(($_POST['name'])) : "";
 		@unlink("/tmp/user.scripts/tmpScripts/$name/log.txt");
 		break;
-	
+
 	case 'applySchedule':
 		$schedules = $_POST['schedule'];
-		
+
 		foreach ($schedules as $schedule) {
 			$script = str_replace('"',"",$schedule[0]);
 			$scriptSchedule['script'] = $script;
@@ -147,7 +147,7 @@ switch ($_POST['action']) {
 			$scriptSchedule['id'] = $schedule[2];
 			$scriptSchedule['custom'] = $schedule[3];
 			$newSchedule[$script] = $scriptSchedule;
-			
+
 			if ( $scriptSchedule['frequency'] == "custom" && $scriptSchedule['custom'] ) {
 				$cronSchedule .= trim($scriptSchedule['custom'])." /usr/local/emhttp/plugins/user.scripts/startCustom.php $script > /dev/null 2>&1\n";
 			}
@@ -161,7 +161,7 @@ switch ($_POST['action']) {
 			@unlink("/boot/config/plugins/user.scripts/customSchedule.cron");
 		}
 		exec("/usr/local/sbin/update_cron");
-		
+
 		echo "Schedule Applied";
 		break;
 	case 'convertLog':
@@ -193,7 +193,7 @@ switch ($_POST['action']) {
 			$o = "nothingDefined=nothingDefined";
 		}
 		echo $o;
-		break;  
+		break;
 	case 'changeName':
 		$script = isset($_POST['script']) ? urldecode(($_POST['script'])) : "";
 		$newName = isset($_POST['newName']) ? urldecode(($_POST['newName'])) : "";
@@ -211,7 +211,7 @@ switch ($_POST['action']) {
 		$scriptContents = str_replace("\r","",$scriptContents);
 		echo $scriptContents;
 		if ( ! $scriptContents ) {
-			echo "#!/bin/bash\n";
+			echo "#!/usr/bin/env bash\n";
 		}
 		break;
 	case 'saveScript':
@@ -238,7 +238,7 @@ switch ($_POST['action']) {
 			}
 		}
 		exec("mkdir -p ".escapeshellarg($folder));
-		file_put_contents("$folder/script","#!/bin/bash\n");
+		file_put_contents("$folder/script","#!/usr/bin/env bash\n");
 		file_put_contents("$folder/name",$scriptName);
 		echo "ok";
 		break;

--- a/source/user.scripts/usr/local/emhttp/plugins/user.scripts/scripts/delete.ds_store/script
+++ b/source/user.scripts/usr/local/emhttp/plugins/user.scripts/scripts/delete.ds_store/script
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 echo "Searching for (and deleting) .DS_Store Files"
 echo "This may take a awhile"
+
 find /mnt/user -maxdepth 9999 -noleaf -type f -name ".DS_Store" -exec rm "{}" \;

--- a/source/user.scripts/usr/local/emhttp/plugins/user.scripts/scripts/delete_dangling_images/script
+++ b/source/user.scripts/usr/local/emhttp/plugins/user.scripts/scripts/delete_dangling_images/script
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-docker rmi $(docker images --quiet --filter "dangling=true")
+docker image prune --force || true
 
-echo Finished
-echo if an error shows above, no dangling images were found to delete
+echo "Finished"
+echo "if an error shows above, no dangling images were found to delete"

--- a/source/user.scripts/usr/local/emhttp/plugins/user.scripts/scripts/viewDockerLogSize/script
+++ b/source/user.scripts/usr/local/emhttp/plugins/user.scripts/scripts/viewDockerLogSize/script
@@ -1,1 +1,3 @@
+#!/usr/bin/env bash
+
 du -ah /var/lib/docker/containers/ | grep -v "/$" | sort -rh | head -60 | grep .log

--- a/source/user.scripts/usr/local/emhttp/plugins/user.scripts/startCustom.php
+++ b/source/user.scripts/usr/local/emhttp/plugins/user.scripts/startCustom.php
@@ -36,7 +36,7 @@ $newPath = str_replace("/usr/local/emhttp/plugins/user.scripts/scripts/","/tmp/u
 exec("mkdir -p ".escapeshellarg(dirname($newPath)));
 $script = file_get_contents($command);
 if ( ! startsWith($script,"#!") ) {
-  $script = "#!/bin/bash\n".$script;
+  $script = "#!/usr/bin/env bash\n".$script;
 }
 $script = str_replace("\r","",$script);
 file_put_contents($newPath,$script);

--- a/source/user.scripts/usr/local/emhttp/plugins/user.scripts/startSchedule.php
+++ b/source/user.scripts/usr/local/emhttp/plugins/user.scripts/startSchedule.php
@@ -18,7 +18,7 @@ if ( ! $schedules ) { return; }
 $unRaidVars = parse_ini_file("/var/local/emhttp/var.ini");
 foreach ($schedules as $scheduledScript) {
   if ( $scheduledScript['frequency'] == $selectedSchedule ) {
-    
+
     $path = $scheduledScript['script'];
     if ( ! is_file($path) ) {
       continue;
@@ -39,7 +39,7 @@ foreach ($schedules as $scheduledScript) {
     exec("mkdir -p ".escapeshellarg(dirname($newPath)));
     $script = file_get_contents($path);
     if ( ! startsWith($script,"#!") ) {
-      $script = "#!/bin/bash\n".$script;
+      $script = "#!/usr/bin/env bash\n".$script;
     }
     $script = str_replace("\r","",$script);
     file_put_contents($newPath,$script);


### PR DESCRIPTION
- Use `#!/usr/bin/env bash` (instead of `#!/bin/bash`) ref: https://stackoverflow.com/questions/16365130/what-is-the-difference-between-usr-bin-env-bash-and-usr-bin-bash
- Replace `docker rmi $(docker images --quiet --filter "dangling=true")` with `docker image prune --force || true`
  - `docker image prune` is built to remove dangling images.
  - `--force` performs the action non-interactively (like `--quiet`)
  - `|| true` prevents the script from failing if the command fails (command failure shouldn't be an issue, but this is just good practice)