### PR TITLE
Change uppercase days of week and months to lower case on Apply.

### DIFF
--- a/source/user.scripts/usr/local/emhttp/plugins/user.scripts/exec.php
+++ b/source/user.scripts/usr/local/emhttp/plugins/user.scripts/exec.php
@@ -146,11 +146,12 @@ switch ($_POST['action']) {
 			$scriptSchedule['frequency'] = $schedule[1];
 			$scriptSchedule['id'] = $schedule[2];
 			$scriptSchedule['custom'] = $schedule[3];
-			$newSchedule[$script] = $scriptSchedule;
 			
 			if ( $scriptSchedule['frequency'] == "custom" && $scriptSchedule['custom'] ) {
+				$scriptSchedule['custom'] = cronCase($scriptSchedule['custom']);
 				$cronSchedule .= trim($scriptSchedule['custom'])." /usr/local/emhttp/plugins/user.scripts/startCustom.php $script > /dev/null 2>&1\n";
 			}
+			$newSchedule[$script] = $scriptSchedule;
 		}
 		file_put_contents("/boot/config/plugins/user.scripts/schedule.json",json_encode($newSchedule,JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
 		file_put_contents("/tmp/user.scripts/schedule.json",json_encode($newSchedule,JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));

--- a/source/user.scripts/usr/local/emhttp/plugins/user.scripts/helpers.php
+++ b/source/user.scripts/usr/local/emhttp/plugins/user.scripts/helpers.php
@@ -5,6 +5,39 @@
 #                                                          #
 ############################################################
 
+##################################################################################
+#                                                                                #
+# Slackware dcron 4.5 only supports lower or camel case DOW and Month alt values #
+# This changes any upper case to lower case                                      #
+#                                                                                #
+##################################################################################
+
+function cronCase($customCron) {
+  // List of 3-letter day and month abbreviations
+  $days = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'];
+  $months = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];
+
+  // Merge and create regex pattern correctly
+  // More complicated without the implode() function
+  // $dateWords = implode('|', array_merge($days, $months));
+  $dateWords = '';
+  foreach (array_merge($days, $months) as $word) {
+      if ($dateWords !== '') {
+          $dateWords .= '|';
+      }
+      $dateWords .= $word;
+  }
+
+  // Use preg_replace_callback to find only FULLY UPPERCASE matches
+  return preg_replace_callback(
+      "/\b($dateWords)\b/", // Ensure proper regex syntax with double quotes
+      function ($matches) {
+          return strtolower($matches[0]); // Convert match to lowercase
+      },
+  $customCron);
+
+}
+
 #################################################################
 #                                                               #
 # Helper function to determine if $haystack begins with $needle #


### PR DESCRIPTION
Fixes #12 
Created helper function to convert upper case D.O.W. and MONTH to lower case to address limitation with dcron only processing lower case and camel case values. 
Any upper case DOW or MONTH value is saved to the schedule.json as lower case and saved to the cron.d with lower case. 

The only issue is that applying the change doesn't refresh the data in the input field with the new data.  

Feedback? 