### PR TITLE
Fixed ! invalid character for html

### DIFF
--- a/source/user.scripts/usr/local/emhttp/plugins/user.scripts/exec.php
+++ b/source/user.scripts/usr/local/emhttp/plugins/user.scripts/exec.php
@@ -234,7 +234,7 @@ switch ($_POST['action']) {
 	case 'addScript':
 		$scriptName = isset($_POST['scriptName']) ? urldecode(($_POST['scriptName'])) : "";
 		$scriptName = trim(htmlspecialchars_decode($scriptName));
-		$scriptName = str_replace(["\\","/","//","\/","*","?",".","'",".",";",":",",","|","+","=","<",">","[","]",'"',"!)"],"",$scriptName);
+		$scriptName = str_replace(["\\","/","//","\/","*","?",".","'",".",";",":",",","|","+","=","<",">","[","]",'"',"!"],"",$scriptName);
 		$folderName = str_replace('"',"",$scriptName);
 		$folderName = str_replace("'","",$folderName);
 		$folderName = str_replacE("&","",$folderName);


### PR DESCRIPTION
"!)" changed to "!" in replace, this issue would cause that html contains ! in id and classes which is invalid and scripts aren't deleteable anymore nor schedule could be changed.