### PR TITLE
Fix abortScript not terminating child processes (rsync)

### DIFF
--- a/source/user.scripts/usr/local/emhttp/plugins/user.scripts/exec.php
+++ b/source/user.scripts/usr/local/emhttp/plugins/user.scripts/exec.php
@@ -30,6 +30,7 @@ switch ($_POST['action']) {
 
 		echo $newPath;
 		break;
+
 	case 'directRunScript':
 		$path = isset($_POST['path']) ? urldecode(($_POST['path'])) : "";
 		$variables = getScriptVariables($path);
@@ -49,6 +50,7 @@ switch ($_POST['action']) {
 		$goodPath = str_replace("/usr/local/emhttp","",$newPath);
 		echo $goodPath.".php";
 		break;
+
 	case 'checkBackground':
 		$allScripts = @array_diff(@scandir("/boot/config/plugins/user.scripts/scripts"),array(".",".."));
 		if ( ! $allScripts ) {
@@ -112,24 +114,76 @@ switch ($_POST['action']) {
 		$o .= "</script>";
 		echo $o;
 		break;
+
 	case 'abortScript':
-		$script = isset($_POST['name']) ? urldecode(($_POST['name'])) : "";
-		
-		$pid = file_get_contents("/tmp/user.scripts/running/$script");
-		exec("pkill -TERM -P $pid");
-		exec("kill -9 $pid");
-		$processListOutput = null;
-		exec("ps aux | grep -i '/tmp/user.scripts/tmpScripts/$script' | grep -v grep", $processListOutput);
-		foreach ($processListOutput as $emergencyKill) {
-			$emergencyKill = str_replace("root","",$emergencyKill);
-			$emergencyKill = trim($emergencyKill);
-			$rawKill = explode(" ",$emergencyKill);
-			logger("Kill pid: ".$rawKill[0]);
-			exec("kill -9 ".$rawKill[0]);
+		$script = isset($_POST['name']) ? urldecode($_POST['name']) : "";
+		$pidFile = "/tmp/user.scripts/running/$script";
+		$pgid = 0;
+		$i = 0;
+		$ret = 1;
+		$is_running = false;
+		$dummy = [];
+		$processListOutput = [];
+
+		if (! file_exists($pidFile)) break;
+
+		$pgid = (int)trim((string)@file_get_contents($pidFile));
+		if ($pgid <= 0) {
+			@unlink($pidFile);
+			break;
 		}
-		@unlink("/tmp/user.scripts/running/$script");
-		file_put_contents("/tmp/user.scripts/finished/$script","aborted");
-		file_put_contents("/tmp/user.scripts/tmpScripts/$script/log.txt","Execution was aborted by user\n\n",FILE_APPEND);
+
+		/* Send TERM to entire process group */
+		exec("kill -TERM -$pgid 2>/dev/null");
+
+		/* Wait up to 10 seconds for group to exit */
+		while ($i < 10) {
+			$is_running = false;
+
+			if (function_exists('posix_kill')) {
+				$is_running = @posix_kill($pgid, 0);
+			} else {
+				exec("kill -0 $pgid 2>/dev/null", $dummy, $ret);
+				$is_running = ($ret === 0);
+			}
+
+			if (! $is_running) {
+				break;
+			}
+
+			sleep(1);
+			$i++;
+		}
+
+		/* Force kill remaining processes in the group */
+		$is_running = false;
+		if (function_exists('posix_kill')) {
+			$is_running = @posix_kill($pgid, 0);
+		} else {
+			exec("kill -0 $pgid 2>/dev/null", $dummy, $ret);
+			$is_running = ($ret === 0);
+		}
+
+		if ($is_running) {
+			exec("kill -9 -$pgid 2>/dev/null");
+		}
+
+		/* Emergency check: catch any leftover processes by script path */
+		exec("ps aux | grep -F " . escapeshellarg("/tmp/user.scripts/tmpScripts/$script") . " | grep -v grep", $processListOutput);
+		foreach ($processListOutput as $emergencyKill) {
+			$emergencyKill = trim(preg_replace('/\s+/', ' ', $emergencyKill));
+			$rawKill = explode(" ", $emergencyKill);
+			if (! empty($rawKill[1]) && ctype_digit($rawKill[1])) {
+				logger("Kill leftover pid: ".$rawKill[1]);
+				exec("kill -9 ".$rawKill[1]." 2>/dev/null");
+			}
+		}
+
+		/* Cleanup */
+		@unlink($pidFile);
+		file_put_contents("/tmp/user.scripts/finished/$script", "aborted");
+		file_put_contents("/tmp/user.scripts/tmpScripts/$script/log.txt", "Execution was aborted by user\n\n", FILE_APPEND);
+
 		break;
 
 	case 'deleteLog':

--- a/source/user.scripts/usr/local/emhttp/plugins/user.scripts/startBackground.php
+++ b/source/user.scripts/usr/local/emhttp/plugins/user.scripts/startBackground.php
@@ -2,32 +2,49 @@
 <?PHP
 require_once("/usr/local/emhttp/plugins/user.scripts/helpers.php");
 
-$command = "";
-foreach ($argv as $arg) {
-  $command .= $arg." ";
-}
-$command = str_replace($argv[0],"",$command);
-$command = trim($command);
+/* Build command from argv */
+$command = trim(str_replace($argv[0], "", implode(" ", $argv)));
 $origCommand = $command;
-$origlogFile = dirname($command)."/log.txt";
+$origLogFile = dirname($command) . "/log.txt";
 $scriptVariables = getScriptVariables($origCommand);
-if ( $scriptVariables['clearLog']??false ) {
-  @unlink($origlogFile);
+
+/* Clear log if requested */
+if ($scriptVariables['clearLog'] ?? false) {
+	@unlink($origLogFile);
 }
-file_put_contents($origlogFile,"Script Starting ".date("M d, Y  H:i.s")."\n\n",FILE_APPEND);
-$command = str_replace(" ","\ ",$command);
-$logFile = str_replace(" ","\ ",$origlogFile);
+
+file_put_contents($origLogFile, "Script Starting " . date("M d, Y H:i.s") . "\n\n", FILE_APPEND);
+
+/* Escape spaces */
+$commandEscaped = str_replace(" ", "\ ", $command);
+$logFile = str_replace(" ", "\ ", $origLogFile);
 $scriptName = basename(dirname($origCommand));
 
-$command = $command." ".($scriptVariables['argumentDefault'] ?? "")." >> $logFile 2>&1";
-file_put_contents("/tmp/user.scripts/running/$scriptName",getmypid());
-file_put_contents($origlogFile,"Full logs for this script are available at $origlogFile\n\n",FILE_APPEND);
-exec($command);
-file_put_contents($origlogFile,"Script Finished ".date("M d, Y  H:i.s")."\n\n",FILE_APPEND);
-unlink("/tmp/user.scripts/running/$scriptName");
-file_put_contents("/tmp/user.scripts/finished/$scriptName","finished");
-file_put_contents($origlogFile,"Full logs for this script are available at $origlogFile\n\n",FILE_APPEND);
+/* Append default arguments and redirect output */
+$commandEscaped .= " " . ($scriptVariables['argumentDefault'] ?? "") . " >> $logFile 2>&1";
 
+/* Put process into its own session (new PGID) */
+if (function_exists('posix_setsid')) {
+	@posix_setsid();
+}
 
+/* Store PGID for abort handling */
+$pgid = function_exists('posix_getpgid') ? @posix_getpgid(getmypid()) : getmypid();
+if ((int)$pgid > 0) {
+	file_put_contents("/tmp/user.scripts/running/$scriptName", (int)$pgid);
+}
+
+file_put_contents($origLogFile, "Full logs for this script are available at $origLogFile\n\n", FILE_APPEND);
+
+/* Execute user script */
+exec($commandEscaped);
+
+file_put_contents($origLogFile, "Script Finished " . date("M d, Y H:i.s") . "\n\n", FILE_APPEND);
+
+/* Cleanup tracking files */
+@unlink("/tmp/user.scripts/running/$scriptName");
+file_put_contents("/tmp/user.scripts/finished/$scriptName", "finished");
+file_put_contents($origLogFile, "Full logs for this script are available at $origLogFile\n\n", FILE_APPEND);
+
+exit(0);
 ?>
-

--- a/source/user.scripts/usr/local/emhttp/plugins/user.scripts/startBackground.php
+++ b/source/user.scripts/usr/local/emhttp/plugins/user.scripts/startBackground.php
@@ -2,49 +2,57 @@
 <?PHP
 require_once("/usr/local/emhttp/plugins/user.scripts/helpers.php");
 
-/* Build command from argv */
-$command = trim(str_replace($argv[0], "", implode(" ", $argv)));
-$origCommand = $command;
-$origLogFile = dirname($command) . "/log.txt";
-$scriptVariables = getScriptVariables($origCommand);
+$rc = 0;
 
-/* Clear log if requested */
-if ($scriptVariables['clearLog'] ?? false) {
-	@unlink($origLogFile);
+/* Build command from argv. */
+$command		= trim(str_replace($argv[0], "", implode(" ", $argv)));
+$orig_command	= $command;
+$orig_log_file	= dirname($command)."/log.txt";
+$script_vars	= getScriptVariables($orig_command);
+$script_name	= basename(dirname($orig_command));
+$running_file	= "/tmp/user.scripts/running/".$script_name;
+$finished_file	= "/tmp/user.scripts/finished/".$script_name;
+
+/* Clear log if requested. */
+if ($script_vars['clearLog'] ?? false) {
+	@unlink($orig_log_file);
 }
 
-file_put_contents($origLogFile, "Script Starting " . date("M d, Y H:i.s") . "\n\n", FILE_APPEND);
+file_put_contents($orig_log_file, "Script Starting ".date("M d, Y H:i.s")."\n\n", FILE_APPEND);
 
-/* Escape spaces */
-$commandEscaped = str_replace(" ", "\ ", $command);
-$logFile = str_replace(" ", "\ ", $origLogFile);
-$scriptName = basename(dirname($origCommand));
-
-/* Append default arguments and redirect output */
-$commandEscaped .= " " . ($scriptVariables['argumentDefault'] ?? "") . " >> $logFile 2>&1";
-
-/* Put process into its own session (new PGID) */
+/* Put wrapper into its own session/process group. */
 if (function_exists('posix_setsid')) {
 	@posix_setsid();
 }
 
-/* Store PGID for abort handling */
+/* Store PGID for abort handling. */
 $pgid = function_exists('posix_getpgid') ? @posix_getpgid(getmypid()) : getmypid();
 if ((int)$pgid > 0) {
-	file_put_contents("/tmp/user.scripts/running/$scriptName", (int)$pgid);
+	file_put_contents($running_file, (string)(int)$pgid);
 }
 
-file_put_contents($origLogFile, "Full logs for this script are available at $origLogFile\n\n", FILE_APPEND);
+file_put_contents($orig_log_file, "Full logs for this script are available at ".$orig_log_file."\n\n", FILE_APPEND);
 
-/* Execute user script */
-exec($commandEscaped);
+/* Build command safely. */
+$default_args	= trim((string)($script_vars['argumentDefault'] ?? ""));
+$exec_cmd		= escapeshellarg($orig_command);
 
-file_put_contents($origLogFile, "Script Finished " . date("M d, Y H:i.s") . "\n\n", FILE_APPEND);
+if ($default_args !== "") {
+	$exec_cmd .= " ".$default_args;
+}
 
-/* Cleanup tracking files */
-@unlink("/tmp/user.scripts/running/$scriptName");
-file_put_contents("/tmp/user.scripts/finished/$scriptName", "finished");
-file_put_contents($origLogFile, "Full logs for this script are available at $origLogFile\n\n", FILE_APPEND);
+$exec_cmd .= " >> ".escapeshellarg($orig_log_file)." 2>&1";
 
-exit(0);
+/* Execute user script. */
+exec($exec_cmd, $out, $return);
+$rc = (int)$return;
+
+file_put_contents($orig_log_file, "Script Finished ".date("M d, Y H:i.s")."\n\n", FILE_APPEND);
+
+/* Cleanup tracking files. */
+@unlink($running_file);
+file_put_contents($finished_file, "finished");
+file_put_contents($orig_log_file, "Full logs for this script are available at ".$orig_log_file."\n\n", FILE_APPEND);
+
+exit($rc);
 ?>


### PR DESCRIPTION
Run background scripts in their own process group and terminate the group on abort.

- Use posix_setsid() to create a new process group
- Store PGID in running file
- Abort uses kill -TERM -$pgid
- Add fallback when posix_kill() is unavailable

Prevents orphaned child processes when scripts spawn subprocesses.